### PR TITLE
[WarpBuild]: shift workflows to warp-ubuntu-latest-x64-4x

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js


### PR DESCRIPTION

## Ready to Warp! 🚀


> [!IMPORTANT]
> We noticed that this repository is public. Please make sure to allow WarpBuild runners to be used by public repositories:
> 1. Go to your organization's [default runner settings page](https://github.com/organizations/WarpBuilds/settings/actions/runner-groups/1).
> 2. Check `Allow public repositories`.
>
> For more information, please refer our [documentation](https://docs.warpbuild.com/public-repos)


This PR was raised by WarpBuild to shift the following workflow(s) to the `warp-ubuntu-latest-x64-4x` runner.

1. [Node.js CI](https://github.com/WarpBuilds/action-debugger/blob/master/.github/workflows/checkin.yml)

Please review the changes in this PR and merge when ready. You can see the status at your [dashboard](https://app.warpbuild.com).

> [!NOTE]
> **All** the jobs in the workflows are shifted to the chosen runner. If you want to shift only a few jobs, please change the values manually in the workflow files.
----
Switches to using fast runners provisioned on [warpbuild.com](https://warpbuild.com).
